### PR TITLE
Gello: fixed (#67)

### DIFF
--- a/gello/Android.mk
+++ b/gello/Android.mk
@@ -36,7 +36,6 @@ endif
 LOCAL_SRC_FILES := ../../../external/gello-build/Gello.apk
 include $(BUILD_PREBUILT)
 else
-ifeq ($(THEY_FIXED_GELLO),true)
 LOCAL_DEX_PREOPT := false
 LOCAL_MODULE_TAGS := optional
 LOCAL_BUILT_MODULE_STEM := package.apk
@@ -48,5 +47,4 @@ LOCAL_HTTP_FILENAME := gello.apk
 LOCAL_HTTP_MD5SUM := $(LOCAL_HTTP_FILENAME).md5sum
 
 include $(BUILD_HTTP_PREBUILT)
-endif
 endif


### PR DESCRIPTION
You can delte this flag now because Gello and dependency are now fixed.
We dont need to use THEY_FIXED_GELLO := true again